### PR TITLE
Change delegates to weak references

### DIFF
--- a/Classes/SpotlightTransitionController.swift
+++ b/Classes/SpotlightTransitionController.swift
@@ -16,7 +16,7 @@ protocol SpotlightTransitionControllerDelegate: class {
 class SpotlightTransitionController: NSObject, UIViewControllerAnimatedTransitioning {
     var isPresent = false
     
-    var delegate: SpotlightTransitionControllerDelegate?
+    weak var delegate: SpotlightTransitionControllerDelegate?
     
     func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
         return 0.25

--- a/Classes/SpotlightViewController.swift
+++ b/Classes/SpotlightViewController.swift
@@ -16,7 +16,7 @@ import UIKit
 
 public class SpotlightViewController: UIViewController {
     
-    public var delegate: SpotlightViewControllerDelegate?
+    public weak var delegate: SpotlightViewControllerDelegate?
     
     private lazy var transitionController: SpotlightTransitionController = {
         let controller = SpotlightTransitionController()


### PR DESCRIPTION
`SpotlightViewController` contained a strong reference to a `SpotlightTransitionController`, which in turn had a strong reference to the `SpotlightViewController` through the `delegate` variable.
This caused a reference cycle that prevented `SpotlightViewController`s from being deallocated, leaking memory.

By changing the `delegate` variable in `SpotlightTransitionControllerDelegate ` to a weak variable, this retain cycle is prevented. I changed the `delegate` in `SpotlightViewControllerDelegate` to a weak variable as well, as this is common practice for delegates.