### PR TITLE
Improved Gecco circle for big screen devices

### DIFF
--- a/GeccoExample/AnnotationViewController.swift
+++ b/GeccoExample/AnnotationViewController.swift
@@ -33,7 +33,7 @@ class AnnotationViewController: SpotlightViewController {
         case 2:
             spotlightView.move(Spotlight.RoundedRect(center: CGPoint(x: screenSize.width / 2, y: 42), size: CGSize(width: 120, height: 40), cornerRadius: 6), moveType: .disappear)
         case 3:
-            spotlightView.move(Spotlight.Oval(center: CGPoint(x: screenSize.width / 2, y: 200), diameter: 220), moveType: .disappear)
+            spotlightView.move(Spotlight.Oval(center: CGPoint(x: screenSize.width / 2, y: 215), diameter: 220), moveType: .disappear)
         case 4:
             dismiss(animated: true, completion: nil)
         default:


### PR DESCRIPTION
I have improved the size the circle orientation on bigger devices like iPhone 8 Plus.

Before:
![screenshot 2018-10-29 at 9 29 02 pm](https://user-images.githubusercontent.com/30840527/47662928-ea3f7b00-dbc1-11e8-9559-32c2c9c22df0.png)

After:
![screenshot 2018-10-29 at 9 28 02 pm](https://user-images.githubusercontent.com/30840527/47662937-ee6b9880-dbc1-11e8-9709-43e589127f0d.png)
